### PR TITLE
Add openai dep to backend

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
     "langgraph-api",
     "fastapi",
     "google-genai",
+    "openai",
 ]
 
 


### PR DESCRIPTION
## Summary
- include `openai` in backend dependencies
- attempt to install new backend package dependencies

## Testing
- `uv pip install --system -e .` *(fails: unsuccessful tunnel)*

------
https://chatgpt.com/codex/tasks/task_e_6845c36ea70c83309fbbf17136df00f1