### PR TITLE
Generalize Gemini wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
-# Gemini Fullstack LangGraph Quickstart
+# Fullstack LangGraph Quickstart
 
-This project demonstrates a fullstack application using a React frontend and a LangGraph-powered backend agent. The agent is designed to perform comprehensive research on a user's query by dynamically generating search terms, querying the web via SerpAPI, reflecting on the results to identify knowledge gaps, and iteratively refining its search until it can provide a well-supported answer with citations. This application serves as an example of building research-augmented conversational AI using LangGraph and Google's Gemini models.
+This project demonstrates a fullstack application using a React frontend and a LangGraph-powered backend agent. The agent is designed to perform comprehensive research on a user's query by dynamically generating search terms, querying the web via SerpAPI, reflecting on the results to identify knowledge gaps, and iteratively refining its search until it can provide a well-supported answer with citations. This application serves as an example of building research-augmented conversational AI using LangGraph and configurable language models (Gemini by default).
 
-![Gemini Fullstack LangGraph](./app.png)
+![Fullstack LangGraph](./app.png)
 
 ## Features
 
 - 💬 Fullstack application with a React frontend and LangGraph backend.
 - 🧠 Powered by a LangGraph agent for advanced research and conversational AI.
-- 🔍 Dynamic search query generation using Google Gemini models.
+- 🔍 Dynamic search query generation using configurable language models (Gemini by default).
 - 🌐 Integrated web research via SerpAPI.
 - 🤔 Reflective reasoning to identify knowledge gaps and refine searches.
 - 📄 Generates answers with citations from gathered sources.
@@ -29,7 +29,7 @@ Follow these steps to get the application running locally for development and te
 
 -   Node.js and npm (or yarn/pnpm)
 -   Python 3.8+
--   **`GEMINI_API_KEY`**: The backend agent requires a Google Gemini API key.
+-   **`GEMINI_API_KEY`**: Required for the default Google Gemini models (or provide another provider's key for your chosen model).
 -   **`OPENAI_API_KEY`**: Required if you enable optional OpenAI features.
 -   **`SERPAPI_API_KEY`**: Used for web search via SerpAPI.
     1.  Navigate to the `backend/` directory.
@@ -72,11 +72,11 @@ The core of the backend is a LangGraph agent defined in `backend/src/agent/graph
 
 ![Agent Flow](./agent.png)
 
-1.  **Generate Initial Queries:** Based on your input, it generates a set of initial search queries using a Gemini model.
-2.  **Web Research:** For each query, it uses the Gemini model together with SerpAPI to find relevant web pages.
-3.  **Reflection & Knowledge Gap Analysis:** The agent analyzes the search results to determine if the information is sufficient or if there are knowledge gaps. It uses a Gemini model for this reflection process.
+1.  **Generate Initial Queries:** Based on your input, it generates a set of initial search queries using a language model (Gemini by default).
+2.  **Web Research:** For each query, it uses the selected model together with SerpAPI to find relevant web pages.
+3.  **Reflection & Knowledge Gap Analysis:** The agent analyzes the search results to determine if the information is sufficient or if there are knowledge gaps. It uses the chosen model for this reflection process.
 4.  **Iterative Refinement:** If gaps are found or the information is insufficient, it generates follow-up queries and repeats the web research and reflection steps (up to a configured maximum number of loops).
-5.  **Finalize Answer:** Once the research is deemed sufficient, the agent synthesizes the gathered information into a coherent answer, including citations from the web sources, using a Gemini model.
+5.  **Finalize Answer:** Once the research is deemed sufficient, the agent synthesizes the gathered information into a coherent answer, including citations from the web sources, using the selected model.
 
 ## Deployment
 
@@ -106,7 +106,7 @@ Open your browser and navigate to `http://localhost:8123/app/` to see the applic
 - [Tailwind CSS](https://tailwindcss.com/) - For styling.
 - [Shadcn UI](https://ui.shadcn.com/) - For components.
 - [LangGraph](https://github.com/langchain-ai/langgraph) - For building the backend research agent.
-- [Google Gemini](https://ai.google.dev/models/gemini) - LLM for query generation, reflection, and answer synthesis.
+- LLM provider (default: [Google Gemini](https://ai.google.dev/models/gemini)) for query generation, reflection, and answer synthesis.
 
 ## License
 

--- a/backend/src/agent/graph.py
+++ b/backend/src/agent/graph.py
@@ -67,8 +67,8 @@ def _init_model(model_name: str, temperature: float):
 def generate_query(state: OverallState, config: RunnableConfig) -> QueryGenerationState:
     """LangGraph node that generates a search queries based on the User's question.
 
-    Uses Gemini 2.0 Flash to create an optimized search query for web research based on
-    the User's question.
+    Uses a language model (Gemini 2.0 Flash by default) to create an optimized
+    search query for web research based on the User's question.
 
     Args:
         state: Current graph state containing the User's question

--- a/backend/src/agent/utils.py
+++ b/backend/src/agent/utils.py
@@ -77,7 +77,7 @@ def insert_citation_markers(text, citations_list):
 
 def get_citations(response, resolved_urls_map):
     """
-    Extracts and formats citation information from a Gemini model's response.
+    Extracts and formats citation information from a language model's response.
 
     This function processes the grounding metadata provided in the response to
     construct a list of citation objects. Each citation object includes the
@@ -85,7 +85,7 @@ def get_citations(response, resolved_urls_map):
     containing formatted markdown links to the supporting web chunks.
 
     Args:
-        response: The response object from the Gemini model, expected to have
+        response: The response object from the language model (Gemini by default), expected to have
                   a structure including `candidates[0].grounding_metadata`.
                   It also relies on a `resolved_map` being available in its
                   scope to map chunk URIs to resolved URLs.

--- a/frontend/src/components/WelcomeScreen.tsx
+++ b/frontend/src/components/WelcomeScreen.tsx
@@ -33,7 +33,7 @@ export const WelcomeScreen: React.FC<WelcomeScreenProps> = ({
       />
     </div>
     <p className="text-xs text-neutral-500">
-      Powered by Google Gemini and LangChain LangGraph.
+      Powered by your chosen language model via LangChain LangGraph.
     </p>
   </div>
 );


### PR DESCRIPTION
## Summary
- neutralize Gemini references in welcome message and docs
- note Gemini as default but support other models
- clarify docstrings for general language model usage

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `make lint` in backend *(fails: Failed to fetch packages)*

------
https://chatgpt.com/codex/tasks/task_e_68464f7338a88330986c2cf8ac47b2cd