### PR TITLE
Add OpenAI build arg and provider key checks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,8 +19,9 @@ RUN npm run build
 # Stage 2: Python Backend
 FROM docker.io/langchain/langgraph-api:3.11
 
-# Allow passing an OpenAI API key at runtime
-ENV OPENAI_API_KEY="${OPENAI_API_KEY}"
+# Accept an OpenAI API key at build time or runtime
+ARG OPENAI_API_KEY
+ENV OPENAI_API_KEY=${OPENAI_API_KEY}
 
 # -- Install UV --
 # First install curl, then install UV using the standalone installer
@@ -45,7 +46,8 @@ ADD backend/ /deps/backend
 RUN uv pip install --system pip setuptools wheel
 # Install dependencies with UV, respecting constraints
 RUN cd /deps/backend && \
-    PYTHONDONTWRITEBYTECODE=1 UV_SYSTEM_PYTHON=1 uv pip install --system -c /api/constraints.txt -e .
+    PYTHONDONTWRITEBYTECODE=1 UV_SYSTEM_PYTHON=1 uv pip install --system -c /api/constraints.txt -e . && \
+    uv pip install --system openai langchain-openai
 # -- End of local dependencies install --
 ENV LANGGRAPH_HTTP='{"app": "/deps/backend/src/agent/app.py:app"}'
 ENV LANGSERVE_GRAPHS='{"agent": "/deps/backend/src/agent/graph.py:graph"}'

--- a/backend/src/agent/graph.py
+++ b/backend/src/agent/graph.py
@@ -30,9 +30,6 @@ from agent.utils import get_research_topic
 
 load_dotenv()
 
-if os.getenv("GEMINI_API_KEY") is None:
-    raise ValueError("GEMINI_API_KEY is not set")
-
 
 def _init_model(model_name: str, temperature: float):
     """Return a chat model instance for the given model name.


### PR DESCRIPTION
## Summary
- update Dockerfile to accept `OPENAI_API_KEY` as a build arg
- install `openai` and `langchain-openai` packages when building
- remove unconditional `GEMINI_API_KEY` check

## Testing
- `make test` *(fails: Failed to fetch openai dependency)*

------
https://chatgpt.com/codex/tasks/task_e_6847679dfdb48330b7ab6c5ff735c9d9