### PR TITLE
Add model selection tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,16 @@ Open your browser and navigate to `http://localhost:8123/app/` to see the applic
 - [LangGraph](https://github.com/langchain-ai/langgraph) - For building the backend research agent.
 - LLM provider (default: [Google Gemini](https://ai.google.dev/models/gemini)) for query generation, reflection, and answer synthesis.
 
+## Running Tests
+
+Unit tests live in `backend/tests`. Run them with:
+
+```bash
+cd backend
+pytest
+```
+
+
 ## License
 
 This project is licensed under the Apache License 2.0. See the [LICENSE](LICENSE) file for details. 

--- a/backend/tests/test_configuration.py
+++ b/backend/tests/test_configuration.py
@@ -1,0 +1,36 @@
+import os
+from unittest.mock import patch
+
+import pytest
+from langchain_core.runnables import RunnableConfig
+
+from agent.configuration import Configuration
+from agent.graph import _init_model
+
+
+def _mock_chat(name):
+    class MockLLM:
+        def __init__(self, *args, **kwargs):
+            self.args = args
+            self.kwargs = kwargs
+
+    return MockLLM
+
+
+@pytest.mark.parametrize(
+    "model,env_key,expected_class",
+    [
+        ("gpt-4o", "OPENAI_API_KEY", "ChatOpenAI"),
+        ("gemini-pro", "GEMINI_API_KEY", "ChatGoogleGenerativeAI"),
+    ],
+)
+def test_from_runnable_config_selects_model(monkeypatch, model, env_key, expected_class):
+    monkeypatch.setenv(env_key, "dummy")
+    cfg = Configuration.from_runnable_config(RunnableConfig(configurable={"query_generator_model": model}))
+    assert cfg.query_generator_model == model
+
+    with patch(f"agent.graph.{expected_class}") as mocked_class:
+        mocked_class.return_value = object()
+        result = _init_model(cfg.query_generator_model, temperature=0.0)
+        assert result is mocked_class.return_value
+        mocked_class.assert_called_once()


### PR DESCRIPTION
## Summary
- add new pytest suite for Configuration model selection
- document how to run tests

## Testing
- `pytest tests -q` *(fails: ModuleNotFoundError: No module named 'langchain_core')*

------
https://chatgpt.com/codex/tasks/task_e_684768d381dc833090cc276f95e56513